### PR TITLE
Support Http with Bearer Token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tests/_output/*
 coverage
 node_modules/
 .phpunit.result.cache
+.idea


### PR DESCRIPTION
- Add the ability to check http(s) health for the routes that need bearer token.

Use this convention on your `Http.yml` or `Https.yml`:
```yml
targets:
  - default:
      urls:
        - '{{ config("app.url") }}'
        - http://google.com
        - http://some-route.with/v2/bearer/token/needed {token}
```